### PR TITLE
Fix issue with `apiVersion` in step.yaml

### DIFF
--- a/steps/aws-sts-step-assume-role/step.yaml
+++ b/steps/aws-sts-step-assume-role/step.yaml
@@ -50,7 +50,7 @@ schemas:
 examples: 
   - summary: assume an STS role
     content: 
-      apiVersion: 1
+      apiVersion: v1
       kind: Step
       name: assume-sts-role
       image: relaysh/aws-sts-step-assume-role


### PR DESCRIPTION
This is causing an issue running `yarn generate` in relay-ui `packages/relay-integrations`:

```sh
$ yarn generate
yarn run v1.22.4
$ node ./src/generator/generate.js
The metadata found in steps/aws-sts-step-assume-role/step.yaml at https://github.com/relay-integrations/relay-aws-sts.git does not match the required schema:
 * .examples[0].content.apiVersion should be string
```