### PR TITLE
Add session token support

### DIFF
--- a/integration.yaml
+++ b/integration.yaml
@@ -1,53 +1,22 @@
-# The schema version. Required. Must be exactly the string "integration/v1".
 apiVersion: integration/v1
-
-# The schema kind. Required. Must be exactly the string "Integration".
 kind: Integration
-
-# The integration slug. Required.
 name: aws-sts
-
-# The release channel for this integration. One of alpha, beta, rc or stable.
-# Optional. Defaults to stable.
 channel: stable
-
-# The version of the integration. Required. This is an arbitrary text string
-# used to identify the bundle of actions for this release. Using dates or
-# incrementing integers is recommended. Each version replaces the one before it
-# on the specified release channel.
-#
-# As a convenience, this information may come from another text file or from a
-# Git tag (if applicable). We may add additional sources in the future.
 version: v20200408
-
-# The shortest possible accurate description of this integration. Required. May
-# just be the name of the service.
 summary: Amazon Web Services Security Token Service
+license: Apache-2.0
+homepage: https://github.com/relay-integrations/relay-aws-sts
+source: git://github.com/relay-integrations/relay-aws-sts.git
 
-# A paragraph or two describing what this integration does. Optional. Markdown.
 description: |
     AWS STS is a web service that enables you to request temporary, limited-privilege
     credentials for AWS Identity and Access Management (IAM) users or for
     users that you authenticate (federated users).
 
-# License information. Optional. If not specified, this integration is assumed
-# to be unlicensed proprietary code. Otherwise, must be a valid SPDX License
-# Expression (similar to npm) or an object referencing a license file.
-license: Apache-2.0
-
-# Owner of this integration. Required, but may be optional in the future if it
-# can be inferred from the provider of the integration.
 owner:
   name: Puppet, Inc.
   email: relay@puppet.com
   url: https://puppet.com
-
-# URL to this integration's Website. Optional.
-homepage: https://github.com/relay-integrations/relay-aws-sts
-
-# URL to this integration's source code. Optional. If the homepage is a GitHub
-# link, may be inferred automatically.
-source: git://github.com/relay-integrations/relay-aws-sts.git
 
 tags:
   - aws

--- a/steps/aws-sts-step-assume-role/output.schema.json
+++ b/steps/aws-sts-step-assume-role/output.schema.json
@@ -1,29 +1,43 @@
 {
-	"$schema": "http://json-schema.org/draft-07/schema#",
-	"type": "object",
-	"properties": {
-		"connection": {
-            "type": "object",
-            "x-relay-connectionType": "aws",
-            "description": "A Relay AWS connection to use",
-            "properties": {
-              "accessKeyID": {
-                "type": "string",
-                "description": "Access Key ID"
-              },
-              "secretAccessKey": {
-                "type": "string",
-                "description": "Secret Access Key"
-              },
-              "sessionToken": {
-                "type": "string",
-                "description":"The token that users must pass to the service API to use the temporary credentials."
-              }
-            }
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "connection": {
+      "type": "object",
+      "x-relay-connectionType": "aws",
+      "description": "A Relay AWS connection to use",
+      "properties": {
+        "accessKeyID": {
+          "type": "string",
+          "description": "The access key ID that identifies the temporary security credentials."
+        },
+        "secretAccessKey": {
+          "type": "string",
+          "description": "The secret access key that can be used to sign requests."
+        },
+        "sessionToken": {
+          "type": "string",
+          "description":"The token that users must pass to the service API to use the temporary credentials."
         }
-	},
-	"required": [
-		"connection"
-	],
-	"additionalProperties": false
+      }
+    },
+    "role": {
+      "type": "object",
+      "description": "The identifiers for the temporary security credentials that the operation returns.",
+      "properties": {
+        "assumedRoleId": {
+          "type": "string",
+          "description": "A unique identifier that contains the role ID and the role session name of the role that is being assumed."
+        },
+        "arn": {
+          "type": "string",
+          "description": "The ARN of the temporary security credentials that are returned from the AssumeRole action."
+        }
+      }
+    }
+  },
+  "required": [
+    "connection"
+  ],
+  "additionalProperties": false
 }

--- a/steps/aws-sts-step-assume-role/spec.schema.json
+++ b/steps/aws-sts-step-assume-role/spec.schema.json
@@ -19,10 +19,14 @@
             "secretAccessKey": {
               "type": "string",
               "description": "Secret Access Key"
+            },
+            "sessionToken": {
+              "type": "string",
+              "description":"Session Token"
             }
           },
           "required": [
-            "accessKeyID", 
+            "accessKeyID",
             "secretAccessKey"
           ]
         },

--- a/steps/aws-sts-step-assume-role/step.py
+++ b/steps/aws-sts-step-assume-role/step.py
@@ -2,23 +2,29 @@
 import boto3
 from nebula_sdk import Interface, Dynamic as D
 
-
 relay = Interface()
 
+sessionToken = None
+try:
+    sessionToken = relay.get(D.aws.connection.sessionToken)
+except Exception:
+    pass
+
 sess = boto3.Session(
-  aws_access_key_id=relay.get(D.aws.connection.accessKeyID),
-  aws_secret_access_key=relay.get(D.aws.connection.secretAccessKey),
-  region_name=relay.get(D.aws.region),
+    aws_access_key_id=relay.get(D.aws.connection.accessKeyID),
+    aws_secret_access_key=relay.get(D.aws.connection.secretAccessKey),
+    aws_session_token=sessionToken,
+    region_name=relay.get(D.aws.region),
 )
 
 sts = sess.client('sts')
 
 try:
-  roleARN = relay.get(D.roleARN)
-  roleSessionName = relay.get(D.roleSessionName)
-except:
-  print('Requires both roleARN and roleSessionName to be defined. Exiting.')
-  exit(1)
+    roleARN = relay.get(D.roleARN)
+    roleSessionName = relay.get(D.roleSessionName)
+except Exception:
+    print('Requires both roleARN and roleSessionName to be defined. Exiting.')
+    exit(1)
 
 print('Creating credentials...\n')
 response = sts.assume_role(
@@ -30,5 +36,12 @@ connection['accessKeyID'] = response['Credentials']['AccessKeyId']
 connection['secretAccessKey'] = response['Credentials']['SecretAccessKey']
 connection['sessionToken'] = response['Credentials']['SessionToken']
 
-print('\nAdding temporary credentials to the outputs `connection`')
+print('\nAdding temporary credentials to the output `connection`')
 relay.outputs.set('connection', connection)
+
+role = {}
+role['assumedRoleId'] = response['AssumedRoleUser']['AssumedRoleId']
+role['arn'] = response['AssumedRoleUser']['Arn']
+
+print('\nAdding assumed role identifiers to the output `role`')
+relay.outputs.set('role', role)

--- a/steps/aws-sts-step-assume-role/step.yaml
+++ b/steps/aws-sts-step-assume-role/step.yaml
@@ -1,60 +1,36 @@
-# The schema version. Required. Must be exactly the string "integration/v1".
 apiVersion: integration/v1
-
-# The schema kind. Required. Must be one of "Query", "Step", or "Trigger"
-# corresponding to its directory location.
 kind: Step
-
-# The name of the action. Required. Must be exactly the name of the directory
-# containing the action.
 name: aws-sts-step-assume-role
-
-# The version of the action. Required. Must be an integer. If specified in the
-# directory name, must be exactly the version in the directory name.
 version: 1
-
-# High-level phrase describing what this action does. Required.
 summary: Assume role
-
-# Single-paragraph explanation of what this action does in more detail.
-# Optional. Markdown.
-description: |
-
-
-# URL or path relative to this file to an icon or icons representing this
-# action. Optional. Defaults to the integration icon.
 icon:
 
-# The mechanism to use to construct this step. Required. Must be an action
-# builder. See the Builders section below.
-build:
-  # The schema version for builders. Required. For now, must be the exact
-  # string "build/v1". We may consider supporting custom third-party builders
-  # in the future.
-  apiVersion: build/v1
+description: |
+  Assumes the given role and returns the assumed credentials and role identifiers.
 
-  # The builder to use. Required.
+build:
+  apiVersion: build/v1
   kind: Docker
 
 publish:
   repository: relaysh/aws-sts-step-assume-role
 
-schemas: 
-  spec: 
+schemas:
+  spec:
     source: file
     file: spec.schema.json
   output:
     source: file
     file: output.schema.json
 
-examples: 
+examples:
   - summary: assume an STS role
-    content: 
+    content:
       apiVersion: v1
       kind: Step
       name: assume-sts-role
       image: relaysh/aws-sts-step-assume-role
-      spec: 
+      spec:
         aws:
           connection: !Connection { type: aws, name: my-aws-account }
           region: !Parameter awsRegion


### PR DESCRIPTION
A session token can optionally be provided as part of the input connection.

Session tokens can be provided to the workflow in a manner similar to this:

```
spec:
  aws:
    connection:
      !Fn.merge
        - !Connection { type: aws, name: "my-aws-connection" }
        - sessionToken: !Secret sessionToken
```

Intrinsic support for session tokens will be added as part of the Relay AWS Connection in the future.

This is important for several reasons:
- Broad support for optional session tokens needs to be added to all relevant AWS steps.
- The _assume role_ step should support temporary credentials from the AWS GetSessionToken operation.
- A _get session token_ step should be added to enable the AWS GetSessionToken operation within Relay.
- This makes dealing with MFA codes slightly easier in the short-term; while the MFA serial number and token code can be provided to both AssumeRole and GetSessionToken, credentials from GetSessionToken are valid for 12 hours by default, while the credentials from AssumeRole are only valid for 1 hour by default. The maximum valid duration for AssumeRole is similarly more limited than GetSessionToken (12 hours and 36 hours, respectively).